### PR TITLE
build out keeman as a binary and docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,69 @@
+name: Build & Publish Docker Images
+# Build & Push rebuilds the tendermint docker image on every push to master and creation of tags
+# and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
+on:
+  workflow_dispatch: # Allow manual trigger
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+
+
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - dockerfile: ./Dockerfile
+            image: ghcr.io/chronicleprotocol/keeman
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Docker metadata (tags, labels, etc)
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+
+      - name: Docker build and Push images
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,46 @@
+name: Build and Test
+on: push
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.18
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Lint Go Code
+        run: |
+          go get -u golang.org/x/lint/golint
+          find ./ -name "*.go" |xargs -IFILE gofmt -s -w FILE
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.18
+      - run: go test ./...
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.18
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build
+        run: go build

--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -1,0 +1,16 @@
+name: Build Go Binary
+on:
+  release:
+    types: [created]
+
+jobs:
+  release-linux-amd64:
+    name: release linux/amd64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1
+      with:
+        github_token: ${{ secrets.RELEASE_BOT_GH_TOKEN }}
+        goos: linux
+        goarch: amd64

--- a/.github/workflows/tag_and_release.yaml
+++ b/.github/workflows/tag_and_release.yaml
@@ -1,0 +1,17 @@
+name: Tag and release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GH_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: patch
+          release_body: ":rocket: Release Notes! :fireworks: "
+          use_github_release_notes: true


### PR DESCRIPTION


| Q                        | A
| ------------------------ | ---
| Service                  | keeman
| Fixed Issues?            | no
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | Yes
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  | no
| License                  | AGPL

### description of pull request:

- build out the binary for keem
- build a docker image 
- adds github actions workflows
- needed for allowing simpler use of keeman without the need for setting up a local go env
