### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4
         with:
           go-version: "1.22"
       - run: go version
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           fetch-depth: '0'
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495
         with:
           go-version: ${{ matrix.go-version }}
       - name: Linting Code
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           version: v1.53
           args: --timeout=10m0s


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/release.yml:14` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/release.yml:19` `actions/setup-go@v4` -> `actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4`
- `.github/workflows/release.yml:25` `goreleaser/goreleaser-action@v4` -> `goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d`
- `.github/workflows/test.yml:22` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/test.yml:26` `actions/setup-go@v3` -> `actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495`
- `.github/workflows/test.yml:30` `golangci/golangci-lint-action@v3` -> `golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc`